### PR TITLE
Make use of native fullscreen hotkey

### DIFF
--- a/frontend/qml/GameView/GameActionBar.qml
+++ b/frontend/qml/GameView/GameActionBar.qml
@@ -265,8 +265,14 @@ Rectangle {
 
             // Fullscreen
             Item {
+                id: fullscreenItem
                 anchors { top: parent.top; bottom: parent.bottom; }
                 width: 24;
+
+                Shortcut {
+                    sequence: StandardKey.FullScreen
+                    onActivated: fullscreenItem.prepareFullscreen()
+                }
 
                 Image {
                     anchors.centerIn: parent;
@@ -280,34 +286,37 @@ Rectangle {
                     source: screenIcon;
                     MouseArea {
                         anchors.fill: parent;
-                        onClicked: {
-                            // If running, ensure the game is paused while the fullscreen transition happens
-                            // Only really applies to OS X
-                            if( gameView.running ) {
-                                coreControl.stateChanged.connect( stateCallback );
-                                coreControl.pause();
-                            }
-
-                            // Otherwise, just do the transition
-                            else {
-                                toggleFullscreen();
-                            }
-                        }
-
-                        // Called when the game (on a separate thread) finally pauses
-                        function stateCallback( newState ) {
-                            coreControl.stateChanged.disconnect( stateCallback );
-                            toggleFullscreen();
-                            coreControl.play();
-                        }
-
-                        function toggleFullscreen() {
-                            if ( root.visibility === Window.FullScreen )
-                                root.visibility = Window.Windowed;
-                            else if ( root.visibility & ( Window.Windowed | Window.Maximized ) )
-                                root.visibility = Window.FullScreen;
-                        }
+                        onClicked: fullscreenItem.prepareFullscreen()
                     }
+                }
+
+
+                function prepareFullscreen() {
+                    // If running, ensure the game is paused while the fullscreen transition happens
+                    // Only really applies to OS X
+                    if( gameView.running ) {
+                        coreControl.stateChanged.connect( stateCallback );
+                        coreControl.pause();
+                    }
+
+                    // Otherwise, just do the transition
+                    else {
+                        toggleFullscreen();
+                    }
+                }
+
+                // Called when the game (on a separate thread) finally pauses
+                function stateCallback( newState ) {
+                    coreControl.stateChanged.disconnect( stateCallback );
+                    toggleFullscreen();
+                    coreControl.play();
+                }
+
+                function toggleFullscreen() {
+                    if ( root.visibility === Window.FullScreen )
+                        root.visibility = Window.Windowed;
+                    else if ( root.visibility & ( Window.Windowed | Window.Maximized ) )
+                        root.visibility = Window.FullScreen;
                 }
             }
 


### PR DESCRIPTION
## Brief:
This commit allows the user to press the native hotkey on their
system to fullscreen the application. This is based on desktop
environment and so is `CTRL+F11` on GNOME and `F11` on most other
platforms.

This works well because some systems (such as chromebooks) do not
have an F11 key and must make use of other system defined hotkeys

Likewise, the key combinations shouldn't conflict with any games

## Changes:

	1. Added `id:` of fullscreenItem to the Item that handles
	   the fullscreen game action

	2. Added contents of the MouseArea `onClicked:` signal
	   to a function inside fullscreenItem called
	   prepareFullscreen()

	3. Added a shortcut to StandardKey.Fullscreen which calls
	   prepareFullscreen() as its callback

## Data
### Here's What it looks like from the main page
###### Also works in a GameView
![72582-hotkey-pressed-pressed-again](https://cloud.githubusercontent.com/assets/6127137/14883688/d2eca586-0cfc-11e6-94e1-01c003a69a9c.gif)


