### PR TITLE
Fix crash when opening add game dialog on KDE.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,10 @@ before_install:
   - sudo apt-get install -qq g++-4.8 libsamplerate0-dev libquazip0-dev
   - sudo apt-get install -qq -y qt57base qt57declarative qt57imageformats qt57location qt57multimedia qt57quickcontrols qt57script qt57svg qt57tools qt57translations libsdl2-dev
   - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
-  - wget https://cmake.org/files/v3.6/cmake-3.6.0-rc3-Linux-x86_64.sh
-  - chmod +x cmake-3.6.0-rc3-Linux-x86_64.sh
+  - wget https://cmake.org/files/v3.7/cmake-3.7.2-Linux-x86_64.sh
+  - chmod +x cmake-3.7.2-Linux-x86_64.sh
   - mkdir cmake-bin
-  - ./cmake-3.6.0-rc3-Linux-x86_64.sh --skip-license --prefix=`pwd`/cmake-bin
+  - ./cmake-3.7.2-Linux-x86_64.sh --skip-license --prefix=`pwd`/cmake-bin
 script:
   - source /opt/qt57/bin/qt57-env.sh
   - mkdir phoenix-build

--- a/frontend/cpp/frontendcommon.h
+++ b/frontend/cpp/frontendcommon.h
@@ -4,6 +4,7 @@
 #ifdef __cplusplus
 
 #include <QtCore>
+#include <QtWidgets>
 #include <QtConcurrent>
 #include <QtQml>
 #include <QtQuick>

--- a/frontend/cpp/main.cpp
+++ b/frontend/cpp/main.cpp
@@ -46,7 +46,7 @@ int main( int argc, char *argv[] ) {
     }
 
     // Runs the main thread's event loop and handles messages from the windowing system
-    QGuiApplication app( argc, argv );
+    QApplication app( argc, argv );
 
 #if defined( Q_OS_WIN )
     // Add the MinGW directory to PATH


### PR DESCRIPTION
Presumably because of some change in Qt, when you try to add a game, it crashes. My guess is because the file open dialog is a QWidget, and QWidget wants the main application instance to be a QApplication and not QGuiApplication. Just include QtWidgets and change the declaration and now it works. I am using Qt 5.7.1.